### PR TITLE
Make all card moves visible

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -878,6 +878,7 @@ function ResetProperties(card)
  */
 function MoveCardTriggers(card, locationfrom, locationto)
 {
+	card.renderer.sprite.visible = true; //all card moves are visible
 	if (locationto !== null)
 	{
 		if ((locationto == corp.archives.cards)||(locationto == runner.heap)||(locationto == corp.HQ.cards)||(locationto == runner.grip))


### PR DESCRIPTION
Especially fixes a bug with Send a Message when scored from R&D during multi-access (since hiding cards is part of the multi-access process).
closes #23 