### PR TITLE
Fix zoomed card zooming in and out during AI turn

### DIFF
--- a/init.js
+++ b/init.js
@@ -1050,8 +1050,12 @@ function Render() {
 
   for (var i = 0; i < zoomedCards.length; i++) {
     //just unzoom and rezoom to reset
+	var savedStoredPos = zoomedCards[i].renderer.storedPosition.y; //save and...
+	var savedStoredRot = zoomedCards[i].renderer.storedRotation;
     zoomedCards[i].renderer.ToggleZoom();
     zoomedCards[i].renderer.ToggleZoom();
+	zoomedCards[i].renderer.storedPosition.y = savedStoredPos; //restore to prevent glitch
+	zoomedCards[i].renderer.storedRotation = savedStoredRot;
   }
 
   //highlight approached/encountered ice
@@ -1079,6 +1083,9 @@ function Render() {
       attackedServerGlow.y
     );
   } else cardRenderer.UpdateGlow(null, 0);
+  
+  //update actual rendered view (this would eventually be done automatically but this can cause issues with hover detection out of sync
+  cardRenderer.app.render(cardRenderer.app.stage);
 }
 
 var counterList = ["advancement", "credits", "virus", "power", "agenda"]; //used for resetting all counters on a card, setting them up for render, etc.


### PR DESCRIPTION
I think I got it! Tricky one because there were two causes: 1) during render the cards are drawn in order then the zoomed card placed on top - the temporary order change could trigger a pointerout event, and 2) the code to move the zoomed card fully onto the screen was causing the card in hand to jump up to meet it temporarily during render.
Both of these are resolved and I have not seen the glitch again during testing (except when an accessed card is zoomed but that's intended behaviour not a glitch).
closes #47 