### PR TITLE
More tweaks to Corp AI

### DIFF
--- a/init.js
+++ b/init.js
@@ -48,6 +48,8 @@ var viewingPile = null; //to look at all cards in a stack
 //values modifiable by effects. Don't access these directly, instead use the relevant function
 var globalProperties = {};
 globalProperties.agendaPointsToWin = 7; //don't modify this or access it directly. Instead use AgendaPointsToWin() for read and card effects to modify.
+//for testing/balancing AIs
+var agendaStolenLocations = [];
 
 //INITIALISATION
 // Performs the initialisation of game state. Contains the main loop for command mode (user interaction).

--- a/mechanics.js
+++ b/mechanics.js
@@ -1145,6 +1145,13 @@ function Steal() {
   OpportunityForAvoidPrevent(corp, "steal", function () {
     ResolveAccess(originalLocation);
     if (intended.steal == null) return;
+	
+	var stolenFromString = "remote";
+	if (originalLocation == corp.HQ.cards) stolenFromString = "HQ";
+	else if (originalLocation == corp.RnD.cards) stolenFromString = "R&D";
+	else if (originalLocation == corp.archives.cards) stolenFromString = "Archives";
+	agendaStolenLocations.push(stolenFromString); //for testing/balancing AIs
+	
     MoveCard(intended.steal, runner.scoreArea);
     intended.steal.faceUp = true;
     if (runner.AI != null) runner.AI.LoseInfoAboutHQCards(intended.steal);

--- a/phase.js
+++ b/phase.js
@@ -699,6 +699,8 @@ phases.corpActionMain = {
               )
                 allowAdvance = false;
             }
+			/*
+			//now handled by corp AI advance code
             if (
               typeof possibleAdvance[i].card.AIAdvancementLimit == "function"
             ) {
@@ -708,6 +710,7 @@ phases.corpActionMain = {
               )
                 allowAdvance = false;
             }
+			*/
             if (allowAdvance) ret.push(possibleAdvance[i]);
           }
         }

--- a/utility.js
+++ b/utility.js
@@ -49,11 +49,13 @@ var capturedLog = [];
     oldLog.apply(console, arguments);
   };
 })();
+var debugging = false;
 (function () {
   var oldLog = console.error;
   console.error = function (message) {
     capturedLog.push("ERROR: "+Readablify(message));
     oldLog.apply(console, arguments);
+	if (debugging) debugger; //pause execution if debugging
   };
 })();
 
@@ -717,6 +719,8 @@ function PlayerWin(player, msgstr) {
   Log("Runner agenda points: " + AgendaPoints(runner));
   Log("R&D size: " + corp.RnD.cards.length);
   Log("Grip size: " + runner.grip.length);
+  console.log("Agendas were stolen from: "+JSON.stringify(agendaStolenLocations)); //for testing/balancing AIs
+  if (debugging) debugger;
 }
 
 /**


### PR DESCRIPTION
Only play Public Trail when can follow up by using it.
Wildcat Strike should also consider max hand size.
More thinking about advancement of Ambush and Hostile cards.
When calculating server/ice protection, don't include unrezzed ice you can't afford to rez.
Consider defensive upgrade value when calculating protection and consider defensive upgrade costs when choosing which ice to rez.
Don't waste Send a Message on ice that has Tranquilizer on it.
Don't always rez ice if it has Tranquilizer on it.
Trash-on-install ice with Tranquilizer on it.
Allow runner into Ambush more easily.
A little more protection on HQ.