### PR TITLE
Improvements to rez usability

### DIFF
--- a/cardrenderer/cardrenderer.js
+++ b/cardrenderer/cardrenderer.js
@@ -1481,7 +1481,7 @@ var CardRenderer = {
 
       this.showFPS = false;
       this.framerates = []; //to calculate a periodic average
-      //key event to toggle fps display and faceoff AI
+      //key events to toggle fps display and faceoff AI, and as shortcut for continue
       window.addEventListener(
         "keydown",
         function (event) {
@@ -1493,6 +1493,9 @@ var CardRenderer = {
 		  else if (event.key == "g" && corp.AI && runner.AI) {
 			pauseFaceoff = !pauseFaceoff;
 			if (!pauseFaceoff) Main();
+		  }
+		  else if (event.key == "Enter") {
+			  $('#footerbutton-n').click();
 		  }
         },
         false
@@ -1695,6 +1698,24 @@ var CardRenderer = {
 		
 		//update counter rotations each frame (but not text, the true here skips that)
 		this.UpdateCounters(true); //doing this every frame might cost us a millisecond or so, that's worth it
+		
+		//update auto-continue timer (and proc, if appropriate)
+		if ($('#timerbar').is(":visible")) {
+			if (autoContinue) autoContinueTimer += PIXI.ticker.shared.elapsedMS / 1000.0;
+			var timeLineLength = 100.0*autoContinueTimer/autoContinueLimit;
+			var procTimer = false;
+			if (timeLineLength > 100) {
+				timeLineLength = 100;
+				procTimer = true;
+			}
+			$('#timerbar').css('width',timeLineLength+'%');
+			if (procTimer) {
+				$('#timerbar').hide();
+				autoContinueTimer = 0.0;
+				$('#footerbutton-n').click();
+			}
+		}
+		
       }, this);
 
       //a special particle trail that travels between breakers and encountered ice

--- a/decks.js
+++ b/decks.js
@@ -545,6 +545,7 @@ var cardBackTexturesCorp = {};
 var cardBackTexturesRunner = {};
 var glowTextures = {};
 var strengthTextures = {};
+var specifiedMentor = URIParameter("mentor");
 function LoadDecks() {
   //Special variables to store card back textures and strength and install cost textures
   var knownTexture = cardRenderer.LoadTexture("images/known.png");
@@ -579,7 +580,6 @@ function LoadDecks() {
   };
 
   //run the intro tutorial, if specified
-  var specifiedMentor = URIParameter("mentor");
   if (specifiedMentor != "") { //later, more options?
     runner.identityCard = InstanceCard(
       specifiedMentor,

--- a/init.js
+++ b/init.js
@@ -59,6 +59,11 @@ var pauseFaceoff = false;
 //for rewind
 var rewinding = false;
 var rewindStates = [];
+//for auto-skip paid ability windows
+var autoContinue = false;
+var autoContinueLimit = 1.0;
+var autoContinueTimer = 0.0;
+
 
 //INITIALISATION
 // Performs the initialisation of game state. Contains the main loop for command mode (user interaction).
@@ -1549,7 +1554,10 @@ function ExecuteChosen(chosenCommand) {
 	  }
     }
 
-    $("#footer").html("<h2>" + footerText + "</h2>");
+	var autoContinueToggleButton = '';
+	//include 'auto' toggle during player downtime
+	if (footerText == "") autoContinueToggleButton = AutoContinueButtonHTML();
+    $("#footer").html("<h2>" + footerText + "</h2>" + autoContinueToggleButton);
 
     Execute(chosenCommand);
 

--- a/phase.js
+++ b/phase.js
@@ -133,6 +133,7 @@ phaseTemplates.standardResponse = {
 			if (CheckApproach() && approachIce < attackedServer.ice.length) {
 				if (card == attackedServer.ice[approachIce]) validRezTypes.push("ice");
 			}
+			//check rezzability inc. costs
 			return FullCheckRez(card, validRezTypes);
 		});
         return ret;

--- a/sets/systemupdate2021.js
+++ b/sets/systemupdate2021.js
@@ -4267,11 +4267,10 @@ cardSet[31051] = {
     {
       text: "Do 1 net damage.",
       Enumerate: function () {
+		//checking attackedServer is equivalent to 'during a run'
 		if (attackedServer) {
 			if (!this.usedThisRun) {
 				if (CheckCounters(this, "agenda", 1)) {
-					//for usability we will only use this on approach
-					if (currentPhase.identifier != "Run 4.5" || approachIce > 0) return [];
 					//**AI code
 					if (corp.AI) {
 						//only on approach to server (4e) and if runner would breach, for maximum effect
@@ -4396,7 +4395,8 @@ cardSet[31053] = {
   RezUsability: function () {
 	//only when could use the ability
 	if (!CheckCounters(this, "advancement", 4)) return false;
-	if (!CheckClicks(corp, 1)) return false;
+    //only rez if there will be clicks to use it (for convenience this excludes first start-of-turn window)
+	if ( currentPhase.identifier.substring(0,6) != "Corp 2" || !CheckClicks(corp, 1) ) return false;
 	return true;
   },
   AITriggerWhenCan: true,
@@ -5199,7 +5199,8 @@ cardSet[31064] = {
   RezUsability: function () {
 	//only when could use the ability
 	if (!CheckCounters(this, "advancement", 1)) return false; //for usability
-	if (!CheckClicks(corp, 1)) return false;
+    //only rez if there will be clicks to use it (for convenience this excludes first start-of-turn window)
+	if ( currentPhase.identifier.substring(0,6) != "Corp 2" || !CheckClicks(corp, 1) ) return false;
 	//**AI code
 	if (corp.AI) {
 		//only if the Runner would actually lose a bunch of credits from this (otherwise better to have the Runner trash it)


### PR DESCRIPTION
- can now rez and trigger Spin Doctor during Corp EOT but sorry I couldn't fix the overheating (closes issue #91)
- an 'auto skip' button can now be used to skip through tedious prompts (it will automatically appear when relevant)
- Enter key will press the relevant continue button
- you should now be able to rez/use of all legal cards in any window as long as at least one card passes the usability check or another action is available (closes issue #110)
- you can now use House of Knives ability any time during the run (previously was only on approach to ice/server)
- added usability check to skip for first start-of-turn Corp window for Ronin, Reversed Accounts, and Regolith
- fixed last move before win/loss sometimes not being shown
- fixed AI accessing HQ over and over (broke this in previous patch)
- fixed clicking empty space sometimes making an arbitrary choice during a button-only choice
- made Red Team's 'run successful' trigger non-automatic (you can now choose whether to fire it or another simultaneous trigger first)